### PR TITLE
feat: 限制标签数量最多为 5 个

### DIFF
--- a/src/views/SubmitPlugin.vue
+++ b/src/views/SubmitPlugin.vue
@@ -91,8 +91,11 @@
                   </n-form-item>
                 </n-grid-item>
                 <n-grid-item>
-                  <n-form-item label="标签（可选，按回车添加）" path="tags">
-                    <n-dynamic-tags v-model:value="formData.tags" />
+                  <n-form-item label="标签（可选，最多 5 个，按回车添加）" path="tags">
+                    <n-dynamic-tags 
+                      v-model:value="formData.tags" 
+                      :max="5"
+                    />
                   </n-form-item>
                 </n-grid-item>
                 <n-grid-item>
@@ -313,6 +316,13 @@ const rules = {
   repo: [
     { required: true, message: '请输入仓库地址', trigger: 'blur' },
     { pattern: /^https:\/\/github\.com\/[\w-]+\/[\w.-]+$/, message: '请输入有效的GitHub仓库地址', trigger: 'blur' }
+  ],
+  tags: [
+    {
+      validator: (_, value) => !Array.isArray(value) || value.length <= 5,
+      message: '标签最多 5 个',
+      trigger: ['change', 'blur']
+    }
   ]
 }
 


### PR DESCRIPTION
## Sourcery 总结

通过更新用户界面、应用组件属性并向表单添加验证规则，将 SubmitPlugin 视图中的标签数量限制为五个。

新功能：
- 通过添加 max 属性和验证规则，在 SubmitPlugin 表单中强制最多五个标签。

增强功能：
- 更新标签输入框的标签，以提及五个标签的限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit the number of tags to five in the SubmitPlugin view by updating the UI, applying a component prop, and adding a validation rule to the form.

New Features:
- Enforce a maximum of five tags in the SubmitPlugin form by adding a max prop and validation rule

Enhancements:
- Update the tag input label to mention the 5-tag limit

</details>